### PR TITLE
Minor radiator fixes

### DIFF
--- a/GameData/SterlingSystems/Thermals/zPatches/B9PS-StackableFilmRadiators.cfg
+++ b/GameData/SterlingSystems/Thermals/zPatches/B9PS-StackableFilmRadiators.cfg
@@ -712,7 +712,7 @@
 			@addedCost = 716
 			@addedMass = 1.2
 		}
-		@SUBTYPE[1150b]
+		@SUBTYPE[1100b]
 		{
 			@addedCost = 239
 			@addedMass = 0.4
@@ -753,7 +753,7 @@
 			@addedCost = 716
 			@addedMass = 1.2
 		}
-		@SUBTYPE[1150b]
+		@SUBTYPE[1100b]
 		{
 			@addedCost = 239
 			@addedMass = 0.4
@@ -789,7 +789,7 @@
 			@addedCost = 239
 			@addedMass = 0.4
 		}
-		@SUBTYPE[1150b]
+		@SUBTYPE[1100b]
 		{
 			@addedCost = 716
 			@addedMass = 1.2

--- a/GameData/SterlingSystems/Thermals/zPatches/B9PS-StackableFilmRadiators.cfg
+++ b/GameData/SterlingSystems/Thermals/zPatches/B9PS-StackableFilmRadiators.cfg
@@ -3,15 +3,15 @@
 	refPowerMWb = #$refPowerMW$
 	@refPowerMWb *= 2
 	refPowerMWc = #$refPowerMW$
-	@refPowerMWc *= 3
+	@refPowerMWc *= 4
 	refPower2MWb = #$refPower2MW$
 	@refPower2MWb *= 2
 	refPower2MWc = #$refPower2MW$
-	@refPower2MWc *= 3
+	@refPower2MWc *= 4
 	refPower3MWb = #$refPower3MW$
 	@refPower3MWb *= 2
 	refPower3MWc = #$refPower3MW$
-	@refPower3MWc *= 3
+	@refPower3MWc *= 4
 	
 	MODULE
 	{


### PR DESCRIPTION
- Updates the VAB tooltip for the 10m-long and 20m-long film radiators' service selection so that the displayed Max Energy Transfer for the 20m-wide services match their actual peak heat rejection, which is 4x that of the 5m-wide versions instead of 3x.
- Makes the 10m-wide Premium services for 10/20/60m film radiators have a higher mass than the 5m-wide versions, just as they are for the Standard services. (The problem seemed to be that they were labeled 1150 rather than 1100.)