### PR TITLE
Fix typo in Profile.cfg

### DIFF
--- a/GameData/SterlingSystemsKerbalism/Profile.cfg
+++ b/GameData/SterlingSystemsKerbalism/Profile.cfg
@@ -13,7 +13,7 @@ Profile
 	}
 	Supply
 	{
-		resource = Fission Pebbles
+		resource = FissionPebbles
 		low_message = Fission Pebbles are almost depleted on $VESSEL@<i>Fission reactions will soon be unavailable</i>
 		empty_message = There is no more Fission Pebbles on $VESSEL@<i>Fission reactions are no longer available</i>
 		refill_message = $VESSEL Fission Pebbles storage refilled@<i>Fission reactions are available once again</i>


### PR DESCRIPTION
[WRN 20:44:18.167] [Kerbalism] Profile.Nodeparse failed to load supply
System.Exception: resource Fission Pebbles doesn't exist
  at KERBALISM.Supply..ctor (ConfigNode node) [0x001ee] in <0d51f7fc071d45809eb1d485b198894d>:0 
  at KERBALISM.Profile.Nodeparse (ConfigNode profile_node) [0x000b0] in <0d51f7fc071d45809eb1d485b198894d>:0 
