### PR TITLE
Add missing SystemHeatConverterKerbalism module for PB reactors

### DIFF
--- a/GameData/SterlingSystemsKerbalism/SystemHeatMSRs.cfg
+++ b/GameData/SterlingSystemsKerbalism/SystemHeatMSRs.cfg
@@ -165,7 +165,7 @@
 	{
 		name = Reliability
 		type = SystemHeatConverterKerbalism
-		title = Molten Satl Reactor
+		title = Molten Salt Reactor
 		repair = Engineer
 		mtbf = 72576000
 		extra_cost = 1.0

--- a/GameData/SterlingSystemsKerbalism/SystemHeatRPBs.cfg
+++ b/GameData/SterlingSystemsKerbalism/SystemHeatRPBs.cfg
@@ -1,0 +1,68 @@
+@PART[strl-rctrpb-*]:NEEDS[Kerbalism,SystemHeat]:FOR[SterlingSystemsKerbalism]
+{
+	@tags ^= :$: _kerbalism
+
+	!MODULE[ModuleSystemHeatConverter],* {}
+	!MODULE[ModuleResourceConverter],* {}
+	!MODULE[ModuleOverheatDisplay] {}
+	!MODULE[ModuleCoreHeat] {}
+
+	// = = Kerbalism = =
+	MODULE
+	{
+		name = SystemHeatConverterKerbalism
+		moduleID = #LOC_strl_reactor_fission // Fission Reactor
+		systemHeatModuleID = nuke
+		shutdownTemperature = 1500
+		systemOutletTemperature = 1300 // temp for freeing water from hydrate regolith. other values could be: 400k for production of hydrazine, 5-600k for decomposition of hydrates, 700 for sabatier process, 373-1000k for high temp electrolysis of water.
+		systemPower = 510 // 0.05% net waste
+		@systemPower *= #$/refPower$
+		systemEfficiency
+		{
+			key = 0 1
+			key = 1 1
+		}
+		ConverterName = #LOC_strl_reactor_fission // Fission Reactor
+		StartActionName = #LOC_strl_reactor_start // Start Reactor
+		StopActionName = #LOC_strl_reactor_stop // Stop Reactor
+		ToggleActionName = #LOC_strl_reactor_toggle //Toggle Reactor
+		FillAmount = 1
+		AutoShutdown = False
+		GeneratesHeat = False
+		UseSpecialistBonus = False
+		INPUT_RESOURCE
+		{
+			ResourceName = FissilePebbles
+			Ratio = 0.0000494473
+			@Ratio *= #$/refPower$
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = FizzledPebbles
+			Ratio = 0.0000494473
+			@Ratio *= #$/refPower$
+			DumpExcess = false
+			FlowMode = ALL_VESSEL
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ThermalPower
+			Ratio = 1019.49 // 1020 // 99.95% net energy
+			@Ratio *= #$/refPower$
+			DumpExcess = true
+			FlowMode = ALL_VESSEL
+		}
+	}
+	
+	MODULE:NEEDS[FeatureReliability]
+	{
+		name = Reliability
+		type = SystemHeatConverterKerbalism
+		title = Pebble Bed Reactor
+		repair = Engineer
+		mtbf = 72576000
+		extra_cost = 1.0
+		extra_mass = 0.2
+	}	
+}


### PR DESCRIPTION
Pebble bed reactors wouldn't run in the background previously. Also corrected a typo in MSR reliability module.