### PR TITLE
Fix FOR[KerbalismDefault] causing false-positives in other patches

### DIFF
--- a/GameData/SterlingSystemsKerbalism/Radiation.cfg
+++ b/GameData/SterlingSystemsKerbalism/Radiation.cfg
@@ -25,7 +25,7 @@
 }
 
 // RTG
-@PART[strl-rctrscm]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
+@PART[strl-rctrscm]:NEEDS[ProfileDefault]:AFTER[KerbalismDefault]
 {
 	MODULE
 	{


### PR DESCRIPTION
Changes the line `@PART[strl-rctrscm]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]` to use `AFTER[KerbalismDefault]` instead of `FOR[KerbalismDefault]`.

Originally, Module Manager would see `FOR[KerbalismDefault]` and register it as an installed mod regardless of the preceding `NEEDS[ProfileDefault]`, which caused false-positives in other mods' compatibility patches (such as Bluedog Design Bureau).